### PR TITLE
Made .js and .html consistent

### DIFF
--- a/bookmarks.js
+++ b/bookmarks.js
@@ -74,8 +74,7 @@ function addBookmark() {
         var tag = $(this).attr("title");
         if (id === "newOne")
         {
-            var checkbox = document.getElementById("TagsCheck");
-            if (checkbox.checked === true) {
+            if (tagsVisible) {
                 decorate($(this), tag);
             }
             $(this).removeAttr("id");


### PR DESCRIPTION
There was no `TagsCheck` checkbox in HTML, but "Toggle Tags"
button and tagsVisible variable. It caused unhandled exception
in `addBookmark()` and no tags of new bookmark displayed.

There is a possibility however that this fix is step backward, and
checkbox really should be in HTML instead of the button. But this
fix is most obvious one.