### PR TITLE
Add tag autocomplete in the Add Bookmark form

### DIFF
--- a/bookmarks.css
+++ b/bookmarks.css
@@ -33,3 +33,6 @@ span.context {
     text-align:right;
     padding: 5px;
 }
+.ui-menu-item {
+  font-size: 10pt;
+}

--- a/bookmarks.js
+++ b/bookmarks.js
@@ -415,22 +415,22 @@ function setupAutocomplete () {
         minLength: 0,
         source: function (request, response) {
             // delegate back to autocomplete, but extract the last term
-            response( $.ui.autocomplete.filter(
-                collectTags(), extractLast( request.term ) ) );
+            response($.ui.autocomplete.filter(
+                collectTags(), extractLast(request.term)));
         },
         focus: function () {
             // prevent value inserted on focus
             return false;
         },
         select: function (event, ui) {
-            var terms = split( this.value );
+            var terms = split(this.value);
             // remove the current input
             terms.pop();
             // add the selected item
             terms.push( ui.item.value );
             // add placeholder to get the comma-and-space at the end
-            terms.push( "" );
-            this.value = terms.join( ", " );
+            terms.push("");
+            this.value = terms.join(", ");
             return false;
         }
     });

--- a/bookmarks.js
+++ b/bookmarks.js
@@ -166,7 +166,7 @@ function addBookmark() {
  * This function collects each distinct tag,
  * stripping whitespace, and placing into sorted order.
  */
-function populateTags()
+function collectTags()
 {
     var tags = {};
     $("#bookmarks").children().each(function () {
@@ -200,10 +200,19 @@ function populateTags()
 
     var cleanKeys = $.unique(keys); // remove duplicate tags
     cleanKeys.sort();
+    return cleanKeys;
+  }
+
+
+/**
+ * Display the tags in the sidebar.
+ */
+function populateTags() {
+    tags = collectTags();
     $("#autotags").html("");
-    for (t in cleanKeys)
+    for (t in tags)
     {
-        $("#autotags").append("<a class=\"tagfilter\" href=\"#" + encodeURIComponent(cleanKeys[t]) + "\">" + cleanKeys[t] + "</a>, ");
+        $("#autotags").append("<a class=\"tagfilter\" href=\"#" + encodeURIComponent(tags[t]) + "\">" + tags[t] + "</a>, ");
     }
 
     /** Remove trailing ", ". */
@@ -384,6 +393,50 @@ function setupEditRemove () {
 }
 
 /**
+ * Setup autocomplete of tags in the "Add/Edit Bookmark" form
+ * Based on http://jqueryui.com/autocomplete/#multiple
+ */
+function setupAutocomplete () {
+    function split (val) {
+        return val.split(/,\s*/);
+    }
+    function extractLast (term) {
+        return split(term).pop();
+    }
+  $( "#newTags" )
+    // don't navigate away from the field on tab when selecting an item
+    .on( "keydown", function (event) {
+        if (event.keyCode === $.ui.keyCode.TAB &&
+                $(this).autocomplete("instance").menu.active) {
+            event.preventDefault();
+        }
+    })
+    .autocomplete({
+        minLength: 0,
+        source: function (request, response) {
+            // delegate back to autocomplete, but extract the last term
+            response( $.ui.autocomplete.filter(
+                collectTags(), extractLast( request.term ) ) );
+        },
+        focus: function () {
+            // prevent value inserted on focus
+            return false;
+        },
+        select: function (event, ui) {
+            var terms = split( this.value );
+            // remove the current input
+            terms.pop();
+            // add the selected item
+            terms.push( ui.item.value );
+            // add placeholder to get the comma-and-space at the end
+            terms.push( "" );
+            this.value = terms.join( ", " );
+            return false;
+        }
+    });
+}
+
+/**
  * Load our bookmarks from the URL `bookmarks.data`, and setup our
  * initial state + listeners.
  */
@@ -433,6 +486,9 @@ function setup () {
         });
 
         setupEditRemove();
+
+        /** Add tag autocomplete to the "add bookmark" form. */
+        setupAutocomplete();
 
         /*
          * Now update the view - in case we were loaded with a

--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
   <head>
     <title>My Bookmarks</title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
-    <script src="https://code.jquery.com/jquery-3.0.0.min.js" integrity="sha256-JmvOoLtYsmqlsWxa7mDSLMwa6dZ9rrIdtrrVYRnDRH0=" crossorigin="anonymous"></script>
+    <script src="http://code.jquery.com/jquery-2.2.4.min.js"></script>
+    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
     <script type="text/javascript">
      //
      // Load an external script.  This is required such that when opening this page as file:///.../index.html we get our external javascript.
@@ -24,6 +25,7 @@
      });
     </script>
     <link rel="StyleSheet" HREF="bookmarks.css" type="text/css" media="screen"/>
+    <link rel="StyleSheet" href="http://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
   </head>
   <body>
     <table id="layout">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <head>
     <title>My Bookmarks</title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
-    <script src="http://code.jquery.com/jquery-2.2.4.min.js"></script>
+    <script src="http://code.jquery.com/jquery-3.1.1.min.js"></script>
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
     <script type="text/javascript">
      //


### PR DESCRIPTION
This adds an autocomplete widget to the "Add/Edit Bookmark" form, so you get tab-autocomplete based on tags you already have in your library. This is based on an example from the jQuery UI documentation: http://jqueryui.com/autocomplete/#multiple

The one potential snag is that I had to downgrade jQuery to get the example working – the example doesn’t seem to have been updated for jQuery 3.0. I don’t know how much about the differences between jQuery 2.x and 3.0 – is there anything in this project that relies on 3.0?