### PR TITLE
fix https links

### DIFF
--- a/bookmarks.data
+++ b/bookmarks.data
@@ -1,24 +1,16 @@
-<li title="debian, planet"><a href="http://planet.debian.org/">Planet Debian</a></li>
-<li title="debian, development"><a href="http://www.debian.org/devel/">Debian Developers' Corner</a></li>
-<li title="sysadmin, planet"><a href="http://planetsysadmin.com/">Planet Sysadmin</a></li>
-<li title="sysadmin, reddit"><a href="http://www.reddit.com/r/sysadmin">Reddit: /r/sysadmin</a></li>
-<li title="blog, microsoft"><a href="http://blogs.msdn.com/b/oldnewthing/">The old new thing</a></li>
-<li title="blog, personal"><a href="https://blog.steve.fi/">Steve Kemp's blog</a></li>
-<li title="personal"><a href="https://steve.fi/">Steve Kemp's Website</a></li>
-<li title="development, personal"><a href="https://github.com/skx/">Steve Kemp's github account</a></li>
-<li title="news"><a href="https://news.ycombinator.com/">Hacker News</a></li>
-<li title="news, edinburgh"><a href="http://www.scotsman.com/edinburgh-evening-news">Edinburgh Evening News</a></li>
-<li title="pippo pelo, NEws"><a href="http://www.bbc.co.uk/news/">BBC News</a></li>
-<li title="personal, sysadmin, debian"><a href="http://debian-administration.org/">Debian Administration</a></li>
-<li title="sysadmin, stackexchange"><a href="http://serverfault.com/">Server Fault</a></li>
-<li title="photography, stackexchange"><a href="http://photo.stackexchange.com/">Photography Exchange</a></li>
-<li title="reddit, photography"><a href="http://www.reddit.com/r/photography/">Reddit /r/photography</a></li>
-<li><a href="http://www.thepondleith.co.uk/">The Pond, Leith</a></li>
-<li title="tools, privacy, online"><a href="https://amiunique.org/fp">Am I unique? Browser fingerprinting</a></li>
-<li title="aws, route53, amazon, github"><a href="https://github.com/open-guides/og-aws">Amazon Web Services — a practical guide</a></li>
-<li><a href="http://blog.darknedgy.net/technology/2015/09/05/0/">A history of modern init systems (1992-2015)</a></li>
-<li title="finnish, wikipedia, language, learning"><a href="http://en.wikipedia.org/wiki/Finnish_numerals">Finnish Numerals</a></li>
-<li title="prison, arrest, wikipedia"><a href="https://en.wikipedia.org/wiki/Cornealious_Michael_Anderson_III">Cornealious Michael Anderson III</a></li>
-<li title="geometry, wikipedia"><a href="https://en.wikipedia.org/wiki/Borromean_rings">Borromean Rings</a></li>
-<li title="geometry, wikipedia"><a href="https://en.wikipedia.org/wiki/Looped_square">Looped square</a></li>
-<li title="helsinki, finland, forum"><a href="http://www.finlandforum.org/">Moving to Finland, living in Finland, expat life in Finland & Finland Forum</a></li>
+<li title="a lire" time="1502896453"><a href="https://framablog.org/2017/05/23/addictions-en-serie/">Addictions en série</a></li>
+<li title="a lire, " time="1502896761"><a href="https://www.cnil.fr/fr/reglement-europeen-sur-la-protection-des-donnees-ce-qui-change-pour-les-professionnels">Règlement européen sur la protection des données : ce qui change pour les professionnels</a></li>
+<li title="enseignement, génie logiciel, " time="1502896554"><a href="http://manu40k.free.fr/">Cours génie logiciel</a></li>
+<li title="enseignement, génie logiciel, tools" time="1502895353"><a href="http://www.umlet.com/umletino/umletino.html">umlet, outil de modélisation en ligne</a></li>
+<li title="enseignement, web" time="1502895123"><a href="https://www.stephaniewalter.fr/formations-cours/initiation-HTML-CSS.pdf">Initiation HTML et CSS, Stéphanie Walter</a></li>
+<li title="enseignement, web" time="1502895423"><a href="http://marksheet.io/">Marksheet, HTML et CSS tuto</a></li>
+<li title="enseignement, web" time="1502896717"><a href="http://jgthms.com/web-design-in-4-minutes/">Web design in 4 min</a></li>
+<li title="enseignement, web, " time="1502895638"><a href="http://guidecss.fr/">Bonnes pratiques CSS</a></li>
+<li title="enseignement, web, " time="1502895670"><a href="http://www.flexboxdefense.com/">Jeu pour apprendre flexbox</a></li>
+<li title="enseignement, web, " time="1502896658"><a href="http://defeo.lu/aws/">Cours web</a></li>
+<li title="enseignement, web," time="1502895218"><a href="https://openclassrooms.com/courses/programmez-en-oriente-objet-en-php?status=published">Programmez en orienté objet en PHP, OpenClassrooms</a></li>
+<li title="enseignement, web," time="1502895269"><a href="https://openclassrooms.com/courses/concevez-votre-site-web-avec-php-et-mysql">Concevez votre site web avec PHP et MySQL</a></li>
+<li title="enseignement, web," time="1502895491"><a href="https://checklists.opquast.com/fr/">opquast, check-lists</a></li>
+<li title="symfony, bonnes pratiques" time="1502895879"><a href="https://speakerdeck.com/webmozart/symfony2-forms-dos-and-donts">Forms dos and don'ts</a></li>
+<li title="symfony, slides" time="1502895828"><a href="http://jeremybarthe.com/slides/2016-domain-driven-design-day/#/48">Ne laissez pas les formulaires Symfony influencer votre modèle</a></li>
+<li title="web, doc, tools" time="1502895752"><a href="https://docsify.js.org/#/">A magical documentation site generator.</a></li>

--- a/bookmarks.data
+++ b/bookmarks.data
@@ -1,5 +1,6 @@
 <li title="a lire" time="1502896453"><a href="https://framablog.org/2017/05/23/addictions-en-serie/">Addictions en série</a></li>
 <li title="a lire, " time="1502896761"><a href="https://www.cnil.fr/fr/reglement-europeen-sur-la-protection-des-donnees-ce-qui-change-pour-les-professionnels">Règlement européen sur la protection des données : ce qui change pour les professionnels</a></li>
+<li title="a lire, enseignement, web, " time="1502897266"><a href="https://buzut.fr/une-histoire-de-polices/">Guide ultime de la typographie pour le web</a></li>
 <li title="enseignement, génie logiciel, " time="1502896554"><a href="http://manu40k.free.fr/">Cours génie logiciel</a></li>
 <li title="enseignement, génie logiciel, tools" time="1502895353"><a href="http://www.umlet.com/umletino/umletino.html">umlet, outil de modélisation en ligne</a></li>
 <li title="enseignement, web" time="1502895123"><a href="https://www.stephaniewalter.fr/formations-cours/initiation-HTML-CSS.pdf">Initiation HTML et CSS, Stéphanie Walter</a></li>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <head>
     <title>My Bookmarks</title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
-    <script src="http://code.jquery.com/jquery-3.1.1.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
     <script type="text/javascript">
      //
@@ -24,8 +24,8 @@
        loadScript("bookmarks.js");
      });
     </script>
-    <link rel="StyleSheet" HREF="bookmarks.css" type="text/css" media="screen"/>
-    <link rel="StyleSheet" href="http://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+    <link rel="StyleSheet" href="bookmarks.css" type="text/css" media="screen"/>
+    <link rel="StyleSheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
   </head>
   <body>
     <table id="layout">


### PR DESCRIPTION
Fixes error (in Chrome) "was loaded over HTTPS, but requested an insecure script 'http://code.jquery.com/jquery-3.1.1.min.js'. This request has been blocked; the content must be served over HTTPS."

Https is enabled by default if you are using the default domain in Github. 

Uses https for jquery links.